### PR TITLE
RDS-210 Apps as volumes

### DIFF
--- a/Dockerfile.rds-local
+++ b/Dockerfile.rds-local
@@ -3,21 +3,33 @@ FROM metaphacts/glam-community:${PLATFORM_VERSION} AS glam-community
 
 FROM gradle:6.8.3-jdk11 AS build
 
-RUN mkdir /tmp/build
+RUN mkdir /tmp/build \
+  && mkdir /tmp/build/rdsapps \
+	&& chown -R 100:0 "/tmp/build/rdsapps" \
+  && chmod -R g=u "/tmp/build/rdsapps" \
+  && chmod -R g+ws "/tmp/build/rdsapps"
+
 WORKDIR /tmp/build
 
 COPY --chown=jetty:jetty . /tmp/build
 COPY --chown=jetty:jetty --from=glam-community /var/lib/jetty/webapps/ROOT.war /tmp/build/ROOT.war
 
+# we are building and extracting all RDS apps at /tmp/build/rdsapps
 RUN echo "platformLocation=/tmp/build/ROOT.war" > /tmp/build/gradle.properties \
   && gradle --info prepareEnvironment \
-  && gradle --info clean appZip
+  && gradle --info clean appZip \
+  && unzip /tmp/build/target/apps/rds-branding.zip -d /tmp/build/rdsapps/rds-branding/ \
+  && unzip /tmp/build/target/apps/rds-local.zip -d /tmp/build/rdsapps/rds-local/ \
+  && unzip /tmp/build/target/apps/rds-local-demo.zip -d /tmp/build/rdsapps/rds-local-demo/ \
+  && unzip /tmp/build/target/apps/rds-services.zip -d /tmp/build/rdsapps/rds-services/ 
 
 
 FROM glam-community
 
-COPY --from=build /tmp/build/target/apps/rds-branding.zip \
-                  /tmp/build/target/apps/rds-local.zip \
-                  /tmp/build/target/apps/rds-local-demo.zip \
-                  /tmp/build/target/apps/rds-services.zip \
-                  /apps/
+# copy built and extracted RDS apps from /tmp/build/rdsapps in "build" image
+COPY --from=build --chown=jetty:root  /tmp/build/rdsapps /rdsapps
+
+ENV MP_APP_1=/rdsapps/rds-branding \
+    MP_APP_2=/rdsapps/rds-services \
+    MP_APP_3=/rdsapps/rds-local \
+    MP_APP_4=/rdsapps/rds-local-demo


### PR DESCRIPTION
Apps are typically deployed to `/apps` which is converted into a Docker volume on first start and any existing content from `/apps` is copied into the volume only once when creating the volume. For baked-in apps like the set of published RDS-L apps that would mean that any updates in newer container images were never re-deployed.

The set of apps that make up the RDS-L deployment are now published in the /rdsapps folder within the container instead and activated via environment variables `MP_APP_<N>` pointing to the respective app.

Any additional apps deployed to `/apps` behave like before and are visible in addition to the ones in `/rdsapps`.

As the RDS-L apps are deployed as folder the start time is actually a bit faster as well as they do not need to be unzipped on first start.